### PR TITLE
mongo connection host via env var

### DIFF
--- a/bin/callsetsStatusmapsRefresher.py
+++ b/bin/callsetsStatusmapsRefresher.py
@@ -2,6 +2,7 @@
 
 # import re, json, yaml
 # from os import path, environ, pardir
+from os import environ
 import sys, datetime
 from isodate import date_isoformat
 from pymongo import MongoClient
@@ -48,7 +49,7 @@ def callsets_refresher():
         
     print("=> Using data values from {}".format(ds_id))
 
-    data_client = MongoClient( )
+    data_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = data_client[ ds_id ]
     cs_coll = data_db[ "callsets" ]
     v_coll = data_db[ "variants" ]

--- a/bin/collationsCreator.py
+++ b/bin/collationsCreator.py
@@ -64,10 +64,10 @@ def collations_creator():
             print( "Creating dummy hierarchy for " + coll_type)
             hier =  _get_dummy_hierarchy( ds_id, coll_type, coll_defs, byc )
 
-        coll_client = MongoClient( )
+        coll_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
         coll_coll = coll_client[ ds_id ][ byc["config"]["collations_coll"] ]
 
-        data_client = MongoClient( )
+        data_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
         data_db = data_client[ ds_id ]
         data_coll = data_db[ collection ]
 
@@ -175,7 +175,7 @@ def get_prefix_hierarchy( ds_id, coll_type, pre_h_f, byc):
     # now adding terms missing from the tree ###################################
 
     print("Looking for missing {} codes in {}.{} ...".format(coll_type, ds_id, coll_defs["scope"]))
-    data_client = MongoClient( )
+    data_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = data_client[ ds_id ]
     data_coll = data_db[coll_defs["scope"]]
 
@@ -275,7 +275,7 @@ def _make_dummy_publication_hierarchy(byc):
     coll_type = "PMID"
     coll_defs = byc["filter_definitions"][coll_type]
     data_db = byc["config"]["services_db"]
-    data_coll = MongoClient( )[ data_db ][ "publications" ]
+    data_coll = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))[ data_db ][ "publications" ]
     query = { "id": { "$regex": coll_defs["pattern"] } }
 
     hier = { }
@@ -309,7 +309,7 @@ def _make_dummy_publication_hierarchy(byc):
 
 def _get_dummy_hierarchy(ds_id, coll_type, coll_defs, byc):
 
-    data_client = MongoClient( )
+    data_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = data_client[ ds_id ]
     data_coll = data_db[ coll_defs["scope"] ]
     data_pat = coll_defs["pattern"]

--- a/bin/collationsPlotter.py
+++ b/bin/collationsPlotter.py
@@ -3,7 +3,7 @@
 import argparse, datetime, re, sys
 from pymongo import MongoClient
 from humps import camelize
-
+from os import environ
 from bycon import *
 
 """
@@ -67,7 +67,7 @@ def collations_plotter():
         fmap_name = "frequencymap_codematches"
 
     results = [ ]
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     for ds_id in byc[ "dataset_ids" ]:
 
         for f_val in coll_ids:

--- a/bin/examplezSampler.py
+++ b/bin/examplezSampler.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 import pymongo
 from pymongo import  MongoClient
+from os import environ
+
 biosample_id_list=[]
-client = MongoClient()
+client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
 
 
 progenetix_biosample_id_list=[]
 progenetix_individual_id_list=[]
 progenetix_variant_id_list=[]
 progenetix_callset_id_list=[]
-client = MongoClient()
+client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
 db=client['progenetix']
 TCGA_cancers=['TCGA.MESO','TCGA.GBM','TCGA.BLCA','TCGA.UVM']
 for cancer in TCGA_cancers:

--- a/bin/examplezUpdater.py
+++ b/bin/examplezUpdater.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from pymongo import MongoClient
-from os import path, pardir, system
+from os import path, pardir, system, environ
 from pathlib import Path
 from progress.bar import Bar
 
@@ -34,7 +34,7 @@ def examplez_updater():
 
     # Access the input value with '-d' flag
     e_ds_id = args.database
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     db_names = list(mongo_client.list_database_names())
 
     # NOTE: I wouldn't use a large framework lime pandas for reading in just
@@ -52,7 +52,7 @@ def examplez_updater():
 
     print('Database to create/update:', e_ds_id)
 
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     db = mongo_client[e_ds_id]
     TODO: One needs an _option_ to select for deletion here!
     if e_ds_id in db_names:

--- a/bin/frequencymapsCreator.py
+++ b/bin/frequencymapsCreator.py
@@ -43,7 +43,7 @@ def frequencymaps_creator():
     
     print("=> Using data values from {}".format(ds_id))
 
-    data_client = MongoClient( )
+    data_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = data_client[ ds_id ]
     coll_coll = data_db[ byc["config"]["collations_coll"] ]
     fm_coll = data_db[ byc["config"]["frequencymaps_coll"] ]

--- a/bin/housekeeping.py
+++ b/bin/housekeeping.py
@@ -42,7 +42,7 @@ def housekeeping():
     }
 
     ds_id = byc["dataset_ids"][0]
-    data_db = MongoClient( )[ ds_id ]
+    data_db = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))[ ds_id ]
 
 
     #>---------------------- info db update ----------------------------------<#
@@ -56,7 +56,7 @@ def housekeeping():
 
         b_info = __dataset_update_counts(byc)
 
-        info_coll = MongoClient( )[ i_db ][ i_coll ]
+        info_coll = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))[ i_db ][ i_coll ]
         info_coll.delete_many( { "date": b_info["date"] } ) #, upsert=True
         info_coll.insert_one( b_info ) #, upsert=True 
         print(f'==> updated entry {b_info["date"]} in {ds_id}.{i_coll}')
@@ -102,7 +102,7 @@ def __update_mongodb_indexes(ds_id, byc):
 
     dt_m = byc["datatable_mappings"]
     b_rt_s = byc["service_config"]["response_types"]
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     data_db = mongo_client[ds_id]
     for r_t, r_d in b_rt_s.items():
 
@@ -133,7 +133,7 @@ def __update_mongodb_indexes(ds_id, byc):
 def __dataset_update_counts(byc):
 
     b_info = { "date": date_isoformat(datetime.datetime.now()), "datasets": { } }
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
 
     # this is independend of the dataset selected for the script & will update
     # for all in any run

--- a/bin/publicationsInserter.py
+++ b/bin/publicationsInserter.py
@@ -1,6 +1,6 @@
 #!/usr/local/bin/python3
 
-from os import path, pardir
+from os import path, pardir, environ
 from pymongo import MongoClient
 from isodate import date_isoformat
 import cgi, cgitb, csv, datetime, requests, sys
@@ -49,7 +49,7 @@ def publications_inserter():
 
     rows = []
 
-    mongo_client = MongoClient()
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
 
     pub_coll = mongo_client["progenetix"]["publications"]
     bios_coll = mongo_client["progenetix"]["biosamples"]

--- a/bin/variantsInserter.py
+++ b/bin/variantsInserter.py
@@ -50,8 +50,8 @@ def variantsInserter():
         delSOvars = input('Delete only the sequence variants ("SO:...") from matched biosamples before insertion?\n(y|N): ')
         delCNVvars = input('Delete only the CNV variants ("EFO:...") from matched biosamples before insertion?\n(y|N): ')
 
-    mongo_client = MongoClient( )
-    var_coll = MongoClient( )[ ds_id ][ "variants" ]
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
+    var_coll = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))[ ds_id ][ "variants" ]
 
     bios_ids = set()
     for c, v in enumerate(variants.data):

--- a/services/collations.py
+++ b/services/collations.py
@@ -44,7 +44,7 @@ def collations():
     # this is all just a bit complex since a multi-dataset response is taken care of...
     s_s = { }
 
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     for ds_id in byc[ "dataset_ids" ]:
         mongo_db = mongo_client[ ds_id ]        
         mongo_coll = mongo_db[ c ]

--- a/services/genespans.py
+++ b/services/genespans.py
@@ -2,7 +2,7 @@
 
 import cgi
 import re, json
-from os import path, pardir
+from os import path, pardir, environ
 import sys
 from pymongo import MongoClient
 

--- a/services/geolocations.py
+++ b/services/geolocations.py
@@ -2,7 +2,7 @@
 
 import cgi
 import re, json
-from os import path, pardir
+from os import path, pardir, environ
 import sys
 from pymongo import MongoClient
 

--- a/services/intervalFrequencies.py
+++ b/services/intervalFrequencies.py
@@ -70,7 +70,7 @@ def interval_frequencies():
 
     results = [ ]
 
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     for ds_id in byc[ "dataset_ids" ]:
 
         for f in byc[ "filters" ]:

--- a/services/ontologymaps.py
+++ b/services/ontologymaps.py
@@ -2,7 +2,7 @@
 
 import cgi
 import re, json
-from os import path, pardir
+from os import path, pardir, environ
 import sys
 from pymongo import MongoClient
 
@@ -60,7 +60,7 @@ def ontologymaps():
 
     c_g = [ ]
     u_c_d = { }
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     mongo_coll = mongo_client[ byc["config"]["services_db"] ][ byc["ontologymaps_coll"] ]
     for o in mongo_coll.find( query, { '_id': False } ):
         for c in o["code_group"]:

--- a/services/publications.py
+++ b/services/publications.py
@@ -54,7 +54,7 @@ def publications():
 
     cgi_break_on_errors(byc)
 
-    mongo_client = MongoClient( )
+    mongo_client = MongoClient(host=environ.get("BYCON_MONGO_HOST", "localhost"))
     pub_db = byc["config"]["services_db"]
     pub_coll = mongo_client[ pub_db ][ "publications" ]
 


### PR DESCRIPTION
`MongoClient` now respects env var `BYCON_MONGO_HOST`. If var not set, default to `localhost`.

I have only tested this with `BYCON_MONGO_HOST` set. Please double-check that the current functionality is retained if the var is not set.