### PR TITLE
added `--no-sudo` to `install.py`

### DIFF
--- a/install.py
+++ b/install.py
@@ -12,7 +12,9 @@ from bycon import *
 """
 The install script copies the relevant services files to the webserver directory
 specified in the `install.yaml` file and sets the file permissions
-accordingly. It requires admin permissions ({sudo_cmd}).
+accordingly. By default, it requires admin permissions (sudo). If you want to run
+it without sudo, invoke it with `--no-sudo`. The current use will need to be able
+to write into the target directories. 
 """
 
 ################################################################################

--- a/install.py
+++ b/install.py
@@ -12,22 +12,26 @@ from bycon import *
 """
 The install script copies the relevant services files to the webserver directory
 specified in the `install.yaml` file and sets the file permissions
-accordingly. It requires admin permissions (sudo).
+accordingly. It requires admin permissions ({sudo_cmd}).
 """
 
 ################################################################################
 ################################################################################
 ################################################################################
 
-def main():
+def main(no_sudo):
 
-    install_services()
+    install_services(no_sudo)
 
 ################################################################################
 ################################################################################
 ################################################################################
 
-def install_services():
+def install_services(no_sudo):
+    if no_sudo:
+        sudo_cmd = ""
+    else:
+        sudo_cmd = "sudo"
 
     yaml = ruamel.yaml.YAML()
     yaml.indent(mapping=2, sequence=4, offset=2)
@@ -66,16 +70,21 @@ def install_services():
             print("¡¡¡ {} does not exist - please check & create !!!".format(s_p))
             exit()
     
-    system(f'sudo rsync -avh {dir_path}/services/ {b_i_d_p}/services/')
-    system(f'sudo rsync -avh {b_s_d_p}/local/ {dir_path}/local/')
-    system(f'sudo rsync -avh {dir_path}/local/ {b_i_d_p}/services/local/')
+    system(f'{sudo_cmd} rsync -avh {dir_path}/services/ {b_i_d_p}/services/')
+    system(f'{sudo_cmd} rsync -avh {b_s_d_p}/local/ {dir_path}/local/')
+    system(f'{sudo_cmd} rsync -avh {dir_path}/local/ {b_i_d_p}/services/local/')
 
-    system(f'sudo chown -R {s_u}:{s_g} {b_i_d_p}')
-    system(f'sudo chmod 775 {b_i_d_p}/services/*.py')
+    system(f'{sudo_cmd} chown -R {s_u}:{s_g} {b_i_d_p}')
+    system(f'{sudo_cmd} chmod 775 {b_i_d_p}/services/*.py')
 
 ################################################################################
 ################################################################################
 ################################################################################
 
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) > 1 and sys.argv[1] == "--no-sudo":
+        no_sudo = True
+    else:
+        no_sudo = False
+
+    main(no_sudo)


### PR DESCRIPTION
adds `--no-sudo` to `install.py` to make the script run in a docker build env (where the user is already root and has no access to sudo).


`./install.py`: behaviours should remain unchanged
`./install.py --no-sudo`: does not invoke commands with `sudo`
